### PR TITLE
Fix JDK source/target levels in projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ ext {
   ] as String[]
 }
 
+def exampleProjects = [ project(':ripc-transport-netty4-examples'),
+                        project(':ripc-rxjava1-examples'),
+                        project(':ripc-reactor-examples') ]
+
 allprojects {
   apply plugin: 'java'
 
@@ -77,6 +81,14 @@ subprojects { subproject ->
     testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
   }
 }
+
+configure(exampleProjects) {
+  compileJava {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
+}
+
 
 project('ripc-core') {
   description = 'Reactive IPC Core Components'
@@ -131,7 +143,7 @@ project('ripc-reactor') {
   dependencies {
     // ripc-tcp
     compile project(":ripc-protocol-tcp"),
-        "io.projectreactor:reactor-net:$reactorVersion"
+        "io.projectreactor:reactor-stream:$reactorVersion"
   }
 }
 

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
@@ -22,7 +22,7 @@ public class ReactorTcpServer<R, W> {
         this.transport = transport;
     }
 
-    public ReactorTcpServer<R, W> start(ReactorTcpHandler<R, W> handler) {
+    public ReactorTcpServer<R, W> start(final ReactorTcpHandler<R, W> handler) {
 
         transport.startAndAwait(new TcpHandler<R, W>() {
             @Override


### PR DESCRIPTION
Here is the JDK level policy enforced by the Gradle build:

* in core modules, sources should be JDK 1.7 compatible
* in core modules, tests should be JDK1.8 compatible
* in example modules, sources+tests should be JDK 1.8 compatible

This commit fixes the gradle build configuration and a missing
`final` keyword in a core implementation class.

This change also switch the `reactor-net` dependency to a
`reactor-stream` dependency.